### PR TITLE
Removed dependency on jmockit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,6 @@ repositories {
     jcenter()
 }
 
-def jmockitVersion = '1.44'
 // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
 // Also defines JUnit 4.
 dependencies {
@@ -95,5 +94,5 @@ jar {
 
 
 test {
-    jvmArgs "-javaagent:${classpath.find { it.name.contains("jmockit") }.absolutePath}"
+
 }


### PR DESCRIPTION
After switching to Mockito as our mocking framework, the outdated Jmockit dependencies were still in the build.gradle file.